### PR TITLE
ENH: wrap y in array

### DIFF
--- a/gat/classifiers.py
+++ b/gat/classifiers.py
@@ -89,7 +89,8 @@ class force_weight(object):
         self._clf = clf
 
     def fit(self, X, y):
-        return self._clf.fit(X, y[:, 0], sample_weight=y[:, 1])
+        return self._clf.fit(X, np.array(y[:, 0], dtype=int),
+                             sample_weight=np.array(y[:, 1]))
 
     def predict(self, X):
         return self._clf.predict(X)


### PR DESCRIPTION
@kingjr this is apparently needed in some cases to force the expected array contiguity. Also it is more explicit and does not rely on the fact that sklean handles y types correctly (float to int).